### PR TITLE
Replace prepublish script with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "jest",
     "build": "tsc",
     "dev": "tsc --watch",
-    "prepublish": "yarn build"
+    "prepare": "yarn build"
   },
   "jest": {
     "preset": "jest-expo"


### PR DESCRIPTION
`prepare` supports running the build step when installing the library from git instead of npm, as is being done with this fork. Also, [prepublish is deprecated](https://docs.npmjs.com/cli/v7/using-npm/scripts).